### PR TITLE
Error in grid-template + using grid-*-end + factoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,20 +41,9 @@
 
 
   @media only screen and (max-width: 480px)   {
-    .main{ width: 100% }
-        .one,.two,.three,.four,.five,.six,.seven,.eight,.nine,.ten,.eleven{
-          grid-column: auto / span 12
-        }
-
-        .one{
-          grid-column: auto / span 6
-        }
-
         #test,#test1{
             grid-column: auto / span 12; background-color: red; grid-row: auto;
         }
-
-
     }
 
 </style>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
     </div>
 
     <div class="twelve"><h2>Swapping Places</h2>
-      <p>Super useful when you working with media queries. You can reorder anything. In this example we used: "grid-row: 20;  grid-column: 4 / 7;" to bring 4 column to 2 place. </p>
+      <p>Super useful when you're working with media queries. You can reorder anything. In this example we used: "grid-row: 20;  grid-column: 4 / 7;" to bring 4 column to 2 place. </p>
     </div>
 
     <div class="styling three">1</div>
@@ -140,7 +140,7 @@
     <div id="test1" class="styling two">6</div>
 
     <div class="twelve"><h2>Nested</h2>
-      <p>You probably never gonna need nested columns with the CSS Grid, but if you do use the class .nested and you have 12 columns inside any other column.</p>
+      <p>You probably never gonna need nested columns with the CSS Grid, but if you do, use the class .nested and you have 12 columns inside any other column.</p>
     </div>
 
       <div class="styling six nested">

--- a/smart-grid.css
+++ b/smart-grid.css
@@ -1,7 +1,7 @@
 .main {
     display: grid;
     grid-gap: 10px;
-    grid-template-columns: repeat(12, fr);
+    grid-template-columns: repeat(12, 1fr);
     margin: 0 auto;
     width: 100%;
     max-width: 1280px;

--- a/smart-grid.css
+++ b/smart-grid.css
@@ -9,7 +9,7 @@
 
 .one, .two, .three, .four, .five, .six,
 .seven, .eight, .nine, .ten, .eleven, .twelve {
-    grid-column: auto / span 12
+    grid-column-end: span 12;
 }
 
 .nested {
@@ -18,22 +18,22 @@
     grid-template-columns: repeat(12, 1fr);
 }
 
-.merge-two-rows { grid-row: auto / span 2 }
-.merge-three-rows { grid-row: auto / span 3 }
-.merge-four-rows { grid-row: auto / span 4 }
-.merge-five-rows { grid-row: auto / span 5 }
-.merge-six-rows { grid-row: auto / span 6 }
+.merge-two-rows { grid-row-end: span 2 }
+.merge-three-rows { grid-row-end: span 3 }
+.merge-four-rows { grid-row-end: span 4 }
+.merge-five-rows { grid-row-end: span 5 }
+.merge-six-rows { grid-row-end: span 6 }
 
 @media only screen and (min-width: 481px) {
-    .one { grid-column: auto / span 1 }
-    .two { grid-column: auto / span 2 }
-    .three { grid-column: auto / span 3 }
-    .four { grid-column: auto / span 4 }
-    .five { grid-column: auto / span 5 }
-    .six { grid-column: auto / span 6 }
-    .seven { grid-column: auto / span 7 }
-    .eight { grid-column: auto / span 8 }
-    .nine { grid-column: auto / span 9 }
-    .ten { grid-column: auto / span 10 }
-    .eleven { grid-column: auto / span 11 }
+    .one { grid-column-end: span 1 }
+    .two { grid-column-end: span 2 }
+    .three { grid-column-end: span 3 }
+    .four { grid-column-end: span 4 }
+    .five { grid-column-end: span 5 }
+    .six { grid-column-end: span 6 }
+    .seven { grid-column-end: span 7 }
+    .eight { grid-column-end: span 8 }
+    .nine { grid-column-end: span 9 }
+    .ten { grid-column-end: span 10 }
+    .eleven { grid-column-end: span 11 }
 }

--- a/smart-grid.css
+++ b/smart-grid.css
@@ -4,6 +4,7 @@
     grid-template-columns: repeat(12, fr);
     margin: 0 auto;
     width: 100%;
+    max-width: 1280px;
 }
 
 .one, .two, .three, .four, .five, .six,
@@ -24,10 +25,6 @@
 .merge-six-rows { grid-row: auto / span 6 }
 
 @media only screen and (min-width: 481px) {
-    .main {
-        max-width: 1280px;
-    }
-
     .one { grid-column: auto / span 1 }
     .two { grid-column: auto / span 2 }
     .three { grid-column: auto / span 3 }


### PR DESCRIPTION
Hi,

I like the simplicity!  
This PR corrects an error and try to improve some others described below:

- there's an error in the value of `grid-template-columns` property: it should be **`1fr`**, not `fr`
- shortcut properties `grid-column` and `grid-row` aren't needed when the first value is `auto`.  
This PR replaces them with `grid-(column|row)-end: span N`
- `max-width: 1280px` can be safely applied also to a resolution less than 481px (it can't have any effect) thus can be written outside the current Media Query.
- some rules can be removed from index.html (you probably have added them to smart-grid.css recently)
- 2 minor typos are also corrected in wording